### PR TITLE
Deploy on DigitalOcean App Platform (Dockerfile + app spec)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+.next
+.git
+.gitignore
+README.md
+Dockerfile
+npm-debug.log
+yarn.lock
+pnpm-lock.yaml
+.env*
+playwright-report
+test-results

--- a/DEPLOY_DIGITALOCEAN.md
+++ b/DEPLOY_DIGITALOCEAN.md
@@ -1,0 +1,62 @@
+# Deploy to DigitalOcean (App Platform)
+
+This repo is a Next.js app.
+
+## Recommended approach
+
+Use **DigitalOcean App Platform** with the included `Dockerfile` and `app.yaml`.
+
+### 1) Create the app
+
+Option A (UI):
+- App Platform → Create App → GitHub → select `Stratos-Eng/stratos-bid`
+- Build & deploy using the **Dockerfile** in the repo
+
+Option B (spec):
+- Use `app.yaml` as your app spec.
+
+### 2) Configure environment variables
+
+Set these as **Secrets** in DO (do not commit real values):
+
+- Database:
+  - `DATABASE_URL`
+  - `ENCRYPTION_KEY`
+- Clerk:
+  - `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`
+  - `CLERK_SECRET_KEY`
+  - `CLERK_WEBHOOK_SECRET`
+- DigitalOcean Spaces (S3-compatible):
+  - `DO_SPACES_BUCKET`
+  - `DO_SPACES_REGION`
+  - `DO_SPACES_ENDPOINT`
+  - `DO_SPACES_KEY`
+  - `DO_SPACES_SECRET`
+- Inngest:
+  - `INNGEST_EVENT_KEY`
+  - `INNGEST_SIGNING_KEY`
+- AI:
+  - `ANTHROPIC_API_KEY` (or switch to an inference proxy)
+
+See `.env.example` for the full list.
+
+### 3) Database
+
+This app uses `drizzle` with `DATABASE_URL`.
+
+You can point `DATABASE_URL` at:
+- DigitalOcean Managed Postgres, or
+- an existing provider (Neon, RDS, etc.)
+
+### 4) Background jobs (Inngest)
+
+This repo includes Inngest. Decide where the Inngest server runs:
+- Managed Inngest cloud, or
+- self-host Inngest on DO as a separate service.
+
+### 5) Local Docker
+
+```bash
+docker build -t stratos-bid .
+docker run --rm -p 3000:3000 --env-file .env stratos-bid
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1
+
+# Multi-stage Dockerfile for Next.js (standalone)
+
+FROM node:20-bookworm-slim AS deps
+WORKDIR /app
+
+# Install dependencies (including dev deps needed for build)
+COPY package.json package-lock.json ./
+RUN npm ci
+
+FROM node:20-bookworm-slim AS builder
+WORKDIR /app
+ENV NEXT_TELEMETRY_DISABLED=1
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# Build Next.js
+RUN npm run build
+
+FROM node:20-bookworm-slim AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# If you use sharp/canvas/etc, you may need additional OS packages here.
+
+# Next.js standalone output
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/public ./public
+
+EXPOSE 3000
+ENV PORT=3000
+
+CMD ["node", "server.js"]

--- a/app.yaml
+++ b/app.yaml
@@ -1,0 +1,27 @@
+# DigitalOcean App Platform spec
+# https://docs.digitalocean.com/products/app-platform/how-to/configure-apps/spec/
+name: stratos-bid
+services:
+  - name: web
+    github:
+      repo: Stratos-Eng/stratos-bid
+      branch: main
+      deploy_on_push: true
+    dockerfile_path: Dockerfile
+    http_port: 3000
+    instance_size_slug: basic-xxs
+    instance_count: 1
+    routes:
+      - path: /
+    envs:
+      - key: NODE_ENV
+        value: production
+      - key: NEXT_TELEMETRY_DISABLED
+        value: "1"
+      # Add all secrets in the DO UI (or here as type: SECRET) before deploying:
+      # - key: DATABASE_URL
+      #   type: SECRET
+      # - key: CLERK_SECRET_KEY
+      #   type: SECRET
+      # - key: ANTHROPIC_API_KEY
+      #   type: SECRET

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  // Needed for container deploys using the "standalone" output (Docker/App Platform)
+  output: "standalone",
+
   // Externalize packages that don't work well with webpack bundling
-  serverExternalPackages: ['canvas'],
+  serverExternalPackages: ["canvas"],
 
   // Empty turbopack config to silence Next.js 16 warning when webpack config is present
   turbopack: {},
@@ -11,7 +14,7 @@ const nextConfig: NextConfig = {
   webpack: (config) => {
     config.watchOptions = {
       ...config.watchOptions,
-      ignored: ['**/services/**', '**/node_modules/**'],
+      ignored: ["**/services/**", "**/node_modules/**"],
     };
     return config;
   },


### PR DESCRIPTION
Adds a production Dockerfile (Next.js standalone), .dockerignore, DigitalOcean App Platform app spec (app.yaml), and a deployment guide.\n\nNotes:\n- next.config.ts sets output=standalone for container deploys.\n- Local next build can OOM on small machines; App Platform build/instance size may need bump, or build image in CI.\n\nNext steps:\n- Set required secrets in App Platform (DATABASE_URL, Clerk keys, Spaces, Inngest, etc.).\n- Decide where Inngest runs (cloud vs self-host).