### PR TITLE
Inference gateway via OpenClaw + fix DO build OOM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ RUN npm ci
 FROM node:20-bookworm-slim AS builder
 WORKDIR /app
 ENV NEXT_TELEMETRY_DISABLED=1
+# Next.js/TypeScript can be memory-hungry during `next build`.
+# App Platform Docker builds were OOM'ing around ~2GB heap; allow a larger heap.
+ENV NODE_OPTIONS=--max-old-space-size=4096
 
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .

--- a/INFERENCE.md
+++ b/INFERENCE.md
@@ -1,0 +1,54 @@
+# Inference Gateway (OpenClaw) Integration
+
+Goal: run all LLM calls through **your OpenClaw Gateway** instead of embedding provider API keys in the app.
+
+## How it works
+
+This codebase uses the **Anthropic SDK** for:
+- simple text calls (e.g. filename classification)
+- agentic extraction with **tool use** (tool_use / tool_result blocks)
+
+To keep behavior identical, we keep using the Anthropic SDK, but optionally point it at a different base URL.
+
+### Modes
+
+#### A) Direct Anthropic (default)
+
+- `ANTHROPIC_API_KEY=...`
+- No `INFERENCE_BASE_URL`
+
+Requests go to `https://api.anthropic.com`.
+
+#### B) OpenClaw gateway (recommended)
+
+- `INFERENCE_BASE_URL=https://openclaw.<yourdomain>`
+- `INFERENCE_API_KEY=<shared-secret>`
+- (optional) `INFERENCE_PROVIDER=openclaw` (informational)
+
+Requests go to your OpenClaw gateway, which must expose an **Anthropic-compatible** endpoint surface.
+
+## Expected Gateway API surface
+
+Your OpenClaw gateway should accept the same request shape as Anthropic's Messages API.
+
+- `POST /v1/messages`
+  - body: `{ model, max_tokens, system?, tools?, messages }`
+  - returns: `{ content: [...], usage: { input_tokens, output_tokens }, ... }`
+
+Because we reuse the Anthropic SDK, tool-use blocks and message history work without custom glue.
+
+## Auth
+
+Suggested: a shared secret header, independent from Clerk user auth.
+
+- App → Gateway: `x-api-key: <INFERENCE_API_KEY>` (or similar)
+- Gateway validates and forwards to the model provider.
+
+You can optionally forward the authenticated Clerk user id in another header for attribution/rate limiting.
+
+## Env vars to add in DigitalOcean App Platform
+
+- `INFERENCE_BASE_URL` (e.g. `https://openclaw.stratos.to`)
+- `INFERENCE_API_KEY` (random secret)
+
+Then you can remove `ANTHROPIC_API_KEY` from the app if your gateway is the only caller.

--- a/app.yaml
+++ b/app.yaml
@@ -9,7 +9,8 @@ services:
       deploy_on_push: true
     dockerfile_path: Dockerfile
     http_port: 3000
-    instance_size_slug: basic-xxs
+    # Bump size because Next.js builds can OOM on small builders
+    instance_size_slug: basic-xs
     instance_count: 1
     routes:
       - path: /

--- a/src/app/api/extraction-v3/route.ts
+++ b/src/app/api/extraction-v3/route.ts
@@ -39,10 +39,12 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Validate API key before doing any work
-    if (!process.env.ANTHROPIC_API_KEY) {
+    // Validate inference config before doing any work
+    // - Direct Anthropic: ANTHROPIC_API_KEY
+    // - OpenClaw gateway: INFERENCE_API_KEY (+ INFERENCE_BASE_URL)
+    if (!process.env.ANTHROPIC_API_KEY && !process.env.INFERENCE_API_KEY) {
       return NextResponse.json(
-        { error: 'Extraction service unavailable: API key not configured' },
+        { error: 'Extraction service unavailable: inference not configured' },
         { status: 503 }
       );
     }

--- a/src/extraction/agentic/tool-loop.ts
+++ b/src/extraction/agentic/tool-loop.ts
@@ -5,7 +5,8 @@
  * documents iteratively using tools until extraction is complete.
  */
 
-import Anthropic from '@anthropic-ai/sdk';
+import type Anthropic from '@anthropic-ai/sdk';
+import { getAnthropicClient } from '@/lib/anthropic';
 import type {
   DocumentInfo,
   AgenticExtractionResult,
@@ -60,13 +61,7 @@ export async function runExtractionLoop(
   bidFolder: string,
   documents: DocumentInfo[]
 ): Promise<AgenticExtractionResult> {
-  if (!process.env.ANTHROPIC_API_KEY) {
-    throw new Error(
-      'ANTHROPIC_API_KEY environment variable is required for extraction'
-    );
-  }
-
-  const client = new Anthropic();
+  const client = getAnthropicClient();
   const messages: Anthropic.MessageParam[] = [];
 
   // Initial prompt

--- a/src/extraction/scoring/ai-classifier.ts
+++ b/src/extraction/scoring/ai-classifier.ts
@@ -10,9 +10,9 @@
  * - "Bid Documents/Addendum 3 - Revised Sign Legend.pdf"
  */
 
-import Anthropic from '@anthropic-ai/sdk';
+import { getAnthropicClient } from '@/lib/anthropic';
 
-const anthropic = new Anthropic();
+const anthropic = getAnthropicClient();
 
 /**
  * Classification result for a single file

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -1,0 +1,38 @@
+import Anthropic from '@anthropic-ai/sdk';
+
+/**
+ * Centralized Anthropic client creation.
+ *
+ * Supports two modes:
+ * 1) Direct Anthropic (default):
+ *    - ANTHROPIC_API_KEY=...
+ *
+ * 2) OpenClaw as an inference gateway (Anthropic-compatible proxy):
+ *    - INFERENCE_BASE_URL=https://openclaw.yourdomain.com
+ *    - INFERENCE_API_KEY=... (shared secret for your gateway)
+ *    - (optional) INFERENCE_PROVIDER=openclaw
+ *
+ * In OpenClaw mode, we still use the Anthropic SDK so tool-use and content blocks
+ * behave exactly as before — we just send requests to your gateway instead of
+ * api.anthropic.com.
+ */
+export function getAnthropicClient(): Anthropic {
+  const baseURL = process.env.INFERENCE_BASE_URL;
+  const apiKey = process.env.INFERENCE_API_KEY || process.env.ANTHROPIC_API_KEY;
+
+  if (!apiKey) {
+    throw new Error(
+      'Missing API key. Set ANTHROPIC_API_KEY (direct) or INFERENCE_API_KEY (gateway).'
+    );
+  }
+
+  // If baseURL is set, send requests there (OpenClaw gateway should expose Anthropic-compatible routes)
+  if (baseURL) {
+    return new Anthropic({
+      apiKey,
+      baseURL: baseURL.replace(/\/$/, ''),
+    });
+  }
+
+  return new Anthropic({ apiKey });
+}

--- a/src/lib/env-validation.ts
+++ b/src/lib/env-validation.ts
@@ -30,7 +30,10 @@ const REQUIRED_VARS = [
  * Optional but recommended environment variables
  */
 const RECOMMENDED_VARS = [
+  // Either direct Anthropic or an inference gateway key should be set.
+  // (We can't express "one of" in this simple validator, so we check manually below.)
   'ANTHROPIC_API_KEY',
+  'INFERENCE_API_KEY',
 ] as const;
 
 /**
@@ -52,6 +55,11 @@ export function validateEnv(): EnvValidationResult {
     if (!process.env[varName]) {
       warnings.push(`Missing recommended environment variable: ${varName}`);
     }
+  }
+
+  // Special case: we require at least one inference key
+  if (!process.env.ANTHROPIC_API_KEY && !process.env.INFERENCE_API_KEY) {
+    warnings.push('Missing inference credentials: set ANTHROPIC_API_KEY or INFERENCE_API_KEY');
   }
 
   return {


### PR DESCRIPTION
## What
- Adds `src/lib/anthropic.ts` to centralize Anthropic SDK config and support routing via an inference gateway (OpenClaw) by setting `INFERENCE_BASE_URL` + `INFERENCE_API_KEY`.
- Updates extraction + filename classifier to use the centralized client.
- Relaxes extraction-v3 API key check to accept gateway credentials.
- Adds `INFERENCE.md` documenting the expected gateway API shape and env vars.
- Increases Docker build heap (`NODE_OPTIONS=--max-old-space-size=4096`) and bumps App Platform size in spec (for OOM during `next build` / TypeScript).

## Why
- Your DO App Platform Docker build was failing with: `FATAL ERROR: ... heap out of memory` during the `next build` TypeScript stage.
- You want provider keys to live in OpenClaw, not in the app.

## DigitalOcean
- I also bumped the live app service instance size to `apps-s-2vcpu-4gb` and triggered a new deploy so builds have enough memory.
