### PR TITLE
Add OpenClaw inference proxy (agent: Stratos-bid)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,8 +26,16 @@ DO_SPACES_SECRET=your-spaces-secret-key
 INNGEST_EVENT_KEY=your-inngest-event-key
 INNGEST_SIGNING_KEY=your-inngest-signing-key
 
-# Anthropic (AI Extraction)
-ANTHROPIC_API_KEY=sk-ant-api03-...
+# Anthropic (legacy direct calls)
+# ANTHROPIC_API_KEY=sk-ant-api03-...
+
+# OpenClaw Inference (recommended)
+# OpenClaw OpenAI-compatible chat completions endpoint:
+#   https://openclaw.stratos.to/v1/chat/completions
+OPENCLAW_INFERENCE_URL=https://openclaw.stratos.to/v1/chat/completions
+OPENCLAW_API_KEY=replace-with-shared-secret
+# Optional override; default is openclaw:Stratos-bid
+OPENCLAW_AGENT_MODEL=openclaw:Stratos-bid
 
 # PlanetBids Credentials
 PLANETBIDS_COMPANY_NAME=Your Company Name

--- a/src/app/api/openclaw/route.ts
+++ b/src/app/api/openclaw/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { openclawChatCompletions } from '@/lib/openclaw';
+
+/**
+ * POST /api/openclaw
+ *
+ * Server-side proxy to OpenClaw's OpenAI-compatible Chat Completions endpoint.
+ *
+ * Why this exists:
+ * - Keeps the OpenClaw API key off the client.
+ * - Allows us to attach the authenticated user id (for future attribution/rate limits).
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json().catch(() => null);
+    if (!body || !Array.isArray(body.messages)) {
+      return NextResponse.json(
+        { error: 'Expected JSON body with { messages: [{role, content}, ...] }' },
+        { status: 400 }
+      );
+    }
+
+    // Basic normalization: only allow the minimal message shape for now.
+    const messages = body.messages.map((m: any) => ({
+      role: m.role,
+      content: String(m.content ?? ''),
+    }));
+
+    const result = await openclawChatCompletions({
+      // Optional override, otherwise uses OPENCLAW_AGENT_MODEL or default
+      model: body.model,
+      messages,
+      temperature: body.temperature,
+    });
+
+    return NextResponse.json({ ok: true, result });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error('[api/openclaw] error', msg);
+    return NextResponse.json({ ok: false, error: msg }, { status: 500 });
+  }
+}

--- a/src/lib/openclaw.ts
+++ b/src/lib/openclaw.ts
@@ -1,0 +1,44 @@
+export type OpenAIChatMessage = {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+};
+
+export type OpenAIChatCompletionRequest = {
+  model: string;
+  messages: OpenAIChatMessage[];
+  stream?: boolean;
+  temperature?: number;
+};
+
+export async function openclawChatCompletions(
+  req: Omit<OpenAIChatCompletionRequest, 'model'> & { model?: string }
+) {
+  const url = process.env.OPENCLAW_INFERENCE_URL;
+  const apiKey = process.env.OPENCLAW_API_KEY;
+
+  if (!url) {
+    throw new Error('OPENCLAW_INFERENCE_URL is not set');
+  }
+  if (!apiKey) {
+    throw new Error('OPENCLAW_API_KEY is not set');
+  }
+
+  const model = req.model || process.env.OPENCLAW_AGENT_MODEL || 'openclaw:Stratos-bid';
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      // Our public-facing auth header; Caddy validates this and injects Bearer upstream.
+      'x-api-key': apiKey,
+    },
+    body: JSON.stringify({ ...req, model }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`OpenClaw chat.completions error ${res.status}: ${text}`);
+  }
+
+  return res.json();
+}


### PR DESCRIPTION
Adds a server-side API route that forwards inference requests to your OpenClaw gateway (OpenAI-compatible chat completions), using `X-API-Key` auth.

- New: `POST /api/openclaw`
- New: `src/lib/openclaw.ts` helper
- Updates `.env.example` with `OPENCLAW_INFERENCE_URL`, `OPENCLAW_API_KEY`, `OPENCLAW_AGENT_MODEL` (default `openclaw:Stratos-bid`).

This is the first step toward moving takeoff inference out of the app and into OpenClaw.
