### PR TITLE
Fix DO App Platform build: lazy DB init

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -18,7 +18,30 @@ if (typeof window === 'undefined' && !_envValidated.__envValidated) {
   }
 }
 
-const sql = neon(process.env.DATABASE_URL!);
-export const db = drizzle(sql, { schema });
+// IMPORTANT:
+// Next.js may evaluate server modules during `next build`.
+// In Docker builds (DigitalOcean App Platform), runtime env vars like DATABASE_URL
+// are not always available to the *build stage*.
+//
+// So we lazily create the DB client and only throw when it is actually used.
+let _db: ReturnType<typeof drizzle> | null = null;
+
+function getDb() {
+  if (_db) return _db;
+  if (!process.env.DATABASE_URL) {
+    throw new Error('DATABASE_URL is not set (required at runtime to use the database)');
+  }
+  const sql = neon(process.env.DATABASE_URL);
+  _db = drizzle(sql, { schema });
+  return _db;
+}
+
+// Provide a proxy so existing imports (`import { db } from '@/db'`) keep working.
+export const db = new Proxy({} as ReturnType<typeof drizzle>, {
+  get(_target, prop) {
+    const real = getDb() as any;
+    return real[prop as any];
+  },
+}) as ReturnType<typeof drizzle>;
 
 export * from './schema';


### PR DESCRIPTION
DigitalOcean App Platform Docker builds run `next build` without reliably injecting runtime env vars into the build stage.

This change makes the DB client lazy so importing `@/db` during build doesn't throw when `DATABASE_URL` isn't present.

Fixes build failure like:
- `Build error occurred: Failed to collect page data for /api/...`
- caused by DB init (`neon(process.env.DATABASE_URL)`) at module import time.
