### PR TITLE
Fix DO builds: don't require runtime secrets at build

### DIFF
--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -20,7 +20,15 @@ export function getAnthropicClient(): Anthropic {
   const baseURL = process.env.INFERENCE_BASE_URL;
   const apiKey = process.env.INFERENCE_API_KEY || process.env.ANTHROPIC_API_KEY;
 
+  // During `next build`, Next.js can evaluate server modules while runtime secrets
+  // are not available in the build environment (common on App Platform).
+  // Avoid throwing at import-time; failures should happen at runtime when inference is used.
+  const isBuild = process.env.NEXT_PHASE === 'phase-production-build';
+
   if (!apiKey) {
+    if (isBuild) {
+      return new Anthropic({ apiKey: 'build-placeholder' });
+    }
     throw new Error(
       'Missing API key. Set ANTHROPIC_API_KEY (direct) or INFERENCE_API_KEY (gateway).'
     );

--- a/src/lib/env-validation.ts
+++ b/src/lib/env-validation.ts
@@ -40,6 +40,13 @@ const RECOMMENDED_VARS = [
  * Validate all environment variables
  */
 export function validateEnv(): EnvValidationResult {
+  // Next.js evaluates some server modules during `next build`.
+  // In Docker builds (e.g. DigitalOcean App Platform), runtime secrets may not be present
+  // in the build environment. Don't fail builds on missing runtime env vars.
+  if (process.env.NEXT_PHASE === 'phase-production-build') {
+    return { valid: true, errors: [], warnings: [] };
+  }
+
   const errors: string[] = [];
   const warnings: string[] = [];
 


### PR DESCRIPTION
Prevents DigitalOcean App Platform Docker builds from failing when runtime secrets (DATABASE_URL, Spaces, inference keys) are not present during `next build` module evaluation.

- `validateEnv()` returns ok during NEXT_PHASE=phase-production-build
- `getAnthropicClient()` no longer throws during build phase when keys are missing
