### PR TITLE
Fix DO builds: pass NEXT_PUBLIC Clerk env into Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,24 @@ ENV NEXT_TELEMETRY_DISABLED=1
 # App Platform Docker builds were OOM'ing around ~2GB heap; allow a larger heap.
 ENV NODE_OPTIONS=--max-old-space-size=4096
 
+# ---- Build-time env forwarding ----
+# When using App Platform with a Dockerfile, runtime env vars are not guaranteed to be available
+# during `docker build`. Next.js inlines NEXT_PUBLIC_* at build time, and Clerk requires a
+# publishable key during prerender.
+#
+# Declare build args for the public vars we need and promote them to ENV so `next build` sees them.
+ARG NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+ARG NEXT_PUBLIC_CLERK_SIGN_IN_URL
+ARG NEXT_PUBLIC_CLERK_SIGN_UP_URL
+ARG NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL
+ARG NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL
+
+ENV NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+ENV NEXT_PUBLIC_CLERK_SIGN_IN_URL=$NEXT_PUBLIC_CLERK_SIGN_IN_URL
+ENV NEXT_PUBLIC_CLERK_SIGN_UP_URL=$NEXT_PUBLIC_CLERK_SIGN_UP_URL
+ENV NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL=$NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL
+ENV NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=$NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL
+
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 


### PR DESCRIPTION
DigitalOcean App Platform Dockerfile builds were failing during `next build` prerender with Clerk errors:
- Missing publishableKey
- Invalid publishableKey

Root cause: with a Dockerfile deploy, runtime env vars are not reliably available during `docker build`, but Next.js inlines `NEXT_PUBLIC_*` at build time.

This PR adds `ARG` + `ENV` forwarding in the Dockerfile for the required Clerk NEXT_PUBLIC vars so `next build` sees them.
