### PR TITLE
Worker env via GH secrets + second-pass verification (estimator-grade)

### DIFF
--- a/.github/workflows/deploy-openclaw-droplet.yml
+++ b/.github/workflows/deploy-openclaw-droplet.yml
@@ -30,5 +30,28 @@ jobs:
         env:
           DROPLET_HOST: ${{ secrets.DROPLET_HOST }}
           DROPLET_USER: ${{ secrets.DROPLET_USER }}
+
+          # Worker secrets (write to /home/openclaw/stratos-bid/.env.worker)
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DO_SPACES_BUCKET: ${{ secrets.DO_SPACES_BUCKET }}
+          DO_SPACES_REGION: ${{ secrets.DO_SPACES_REGION }}
+          DO_SPACES_ENDPOINT: ${{ secrets.DO_SPACES_ENDPOINT }}
+          DO_SPACES_KEY: ${{ secrets.DO_SPACES_KEY }}
+          DO_SPACES_SECRET: ${{ secrets.DO_SPACES_SECRET }}
+
+          OPENCLAW_INFERENCE_URL: ${{ secrets.OPENCLAW_INFERENCE_URL }}
+          OPENCLAW_API_KEY: ${{ secrets.OPENCLAW_API_KEY }}
+          OPENCLAW_AGENT_MODEL: ${{ secrets.OPENCLAW_AGENT_MODEL }}
         run: |
-          ssh "${DROPLET_USER}@${DROPLET_HOST}" 'bash -s' < ./scripts/deploy-droplet.sh
+          # Forward env vars over SSH so deploy script can write the worker env file.
+          ssh "${DROPLET_USER}@${DROPLET_HOST}" \
+            "DATABASE_URL='${DATABASE_URL}' \
+             DO_SPACES_BUCKET='${DO_SPACES_BUCKET}' \
+             DO_SPACES_REGION='${DO_SPACES_REGION}' \
+             DO_SPACES_ENDPOINT='${DO_SPACES_ENDPOINT}' \
+             DO_SPACES_KEY='${DO_SPACES_KEY}' \
+             DO_SPACES_SECRET='${DO_SPACES_SECRET}' \
+             OPENCLAW_INFERENCE_URL='${OPENCLAW_INFERENCE_URL}' \
+             OPENCLAW_API_KEY='${OPENCLAW_API_KEY}' \
+             OPENCLAW_AGENT_MODEL='${OPENCLAW_AGENT_MODEL}' \
+             bash -s" < ./scripts/deploy-droplet.sh

--- a/scripts/deploy-droplet.sh
+++ b/scripts/deploy-droplet.sh
@@ -44,6 +44,42 @@ echo "[deploy] build"
 # For now, we skip `next build` here.
 echo "[deploy] skipping next build (worker not yet implemented)"
 
+echo "[deploy] write worker env file (if secrets provided)"
+# These env vars should be provided via GitHub Actions Environment secrets.
+# We only write keys that are present to avoid clobbering manual edits.
+ENV_FILE="${APP_DIR}/.env.worker"
+mkdir -p "${APP_DIR}"
+
+write_kv () {
+  local key="$1"
+  local val="$2"
+  if [[ -n "${val}" ]]; then
+    echo "${key}=${val}" >> "${ENV_FILE}.tmp"
+  fi
+}
+
+# If *any* worker secret is present, rewrite the env file atomically.
+if [[ -n "${DATABASE_URL:-}" || -n "${DO_SPACES_BUCKET:-}" || -n "${DO_SPACES_KEY:-}" || -n "${OPENCLAW_INFERENCE_URL:-}" || -n "${OPENCLAW_API_KEY:-}" ]]; then
+  echo "[deploy] updating ${ENV_FILE}"
+  : > "${ENV_FILE}.tmp"
+  write_kv "NODE_ENV" "production"
+  write_kv "DATABASE_URL" "${DATABASE_URL:-}"
+  write_kv "DO_SPACES_BUCKET" "${DO_SPACES_BUCKET:-}"
+  write_kv "DO_SPACES_REGION" "${DO_SPACES_REGION:-}"
+  write_kv "DO_SPACES_ENDPOINT" "${DO_SPACES_ENDPOINT:-}"
+  write_kv "DO_SPACES_KEY" "${DO_SPACES_KEY:-}"
+  write_kv "DO_SPACES_SECRET" "${DO_SPACES_SECRET:-}"
+  write_kv "OPENCLAW_INFERENCE_URL" "${OPENCLAW_INFERENCE_URL:-}"
+  write_kv "OPENCLAW_API_KEY" "${OPENCLAW_API_KEY:-}"
+  write_kv "OPENCLAW_AGENT_MODEL" "${OPENCLAW_AGENT_MODEL:-}"
+  write_kv "TAKEOFF_WORKER_POLL_MS" "${TAKEOFF_WORKER_POLL_MS:-}"
+  write_kv "TAKEOFF_WORKER_CLAIM_TIMEOUT_MS" "${TAKEOFF_WORKER_CLAIM_TIMEOUT_MS:-}"
+  mv "${ENV_FILE}.tmp" "${ENV_FILE}"
+  chmod 600 "${ENV_FILE}" || true
+else
+  echo "[deploy] no worker secrets provided; leaving ${ENV_FILE} unchanged"
+fi
+
 echo "[deploy] restart worker service (if present)"
 if systemctl list-unit-files | grep -q '^stratos-takeoff-worker\.service'; then
   sudo systemctl restart stratos-takeoff-worker

--- a/src/extraction/estimator-takeoff.ts
+++ b/src/extraction/estimator-takeoff.ts
@@ -1,0 +1,323 @@
+import { execSync } from 'child_process';
+import { openclawChatCompletions } from '@/lib/openclaw';
+
+export type EvidenceSnippet = {
+  filename: string;
+  page: number;
+  kind: 'schedule' | 'legend' | 'egress' | 'keynote' | 'code' | 'plan' | 'unknown';
+  text: string;
+};
+
+export type TakeoffItem = {
+  category: string;
+  description: string;
+  qty: string;
+  confidence: number; // 0-1
+  sources: Array<{
+    filename: string;
+    page: number;
+    sheetRef?: string;
+    evidence: string;
+    whyAuthoritative: string;
+  }>;
+  reviewFlags?: string[];
+};
+
+export type EstimatorTakeoffResult = {
+  items: TakeoffItem[];
+  discrepancyLog: Array<{ issue: string; sources: { filename: string; page: number; evidence: string }[] }>;
+  missingItems: string[];
+  reviewFlags: string[];
+  notes: string;
+  verification?: {
+    method: string;
+    checkedItems: number;
+    issuesFound: number;
+    notes: string;
+  };
+};
+
+const KEYWORD_SETS: Array<{ kind: EvidenceSnippet['kind']; keywords: RegExp }> = [
+  { kind: 'schedule', keywords: /sign(\s|-)schedule|signage\s+schedule|sign\s+type|type\s+schedule|schedule\s+of\s+sign/i },
+  { kind: 'legend', keywords: /legend|sign\s+legend/i },
+  { kind: 'egress', keywords: /egress|occupant\s+load|exit\s+sign|exit\s+signage/i },
+  { kind: 'keynote', keywords: /keynote/i },
+  { kind: 'code', keywords: /code\s+requirement|ada|accessib|california\s+building\s+code|cbc\b|health\s+code|pool/i },
+  { kind: 'plan', keywords: /floor\s+plan|electrical\s+plan|reflected\s+ceiling|site\s+plan/i },
+];
+
+function detectKind(text: string): EvidenceSnippet['kind'] {
+  for (const s of KEYWORD_SETS) {
+    if (s.keywords.test(text)) return s.kind;
+  }
+  return 'unknown';
+}
+
+function pdftotextPage(pdfPath: string, page: number): string {
+  try {
+    return execSync(`pdftotext -layout -f ${page} -l ${page} "${pdfPath}" -`, {
+      encoding: 'utf-8',
+      maxBuffer: 10 * 1024 * 1024,
+    });
+  } catch {
+    return '';
+  }
+}
+
+function getPdfPageCount(pdfPath: string): number | null {
+  try {
+    const out = execSync(`pdfinfo "${pdfPath}"`, { encoding: 'utf-8', maxBuffer: 1024 * 1024 });
+    const m = out.match(/Pages:\s+(\d+)/i);
+    return m ? Number(m[1]) : null;
+  } catch {
+    return null;
+  }
+}
+
+function pickSnippetsFromPage(text: string, maxSnippets = 2): string[] {
+  const lines = text
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length >= 8);
+
+  const scored = lines
+    .map((l) => {
+      const score =
+        (/(qty|quantity|count|no\.|ea\b|each\b)/i.test(l) ? 3 : 0) +
+        (/\b(D|P|TS|ID|R)\s?-?\d{1,2}\b/i.test(l) ? 3 : 0) +
+        (/sign|exit|egress|ada|tactile/i.test(l) ? 2 : 0) +
+        (l.length > 80 ? 1 : 0);
+      return { l, score };
+    })
+    .sort((a, b) => b.score - a.score);
+
+  const picked: string[] = [];
+  for (const { l } of scored) {
+    if (picked.length >= maxSnippets) break;
+    if (picked.some((p) => p === l)) continue;
+    picked.push(l.slice(0, 400));
+  }
+
+  return picked;
+}
+
+function extractLikelySignCodes(items: TakeoffItem[], limit = 25): string[] {
+  const codes = new Set<string>();
+  const re = /\b([A-Z]{1,3}\s?-?\d{1,2})\b/g;
+  for (const it of items) {
+    const hay = `${it.description} ${it.sources?.map((s) => s.evidence).join(' ')}`;
+    let m: RegExpExecArray | null;
+    while (true) {
+      m = re.exec(hay);
+      if (!m) break;
+      const c = m[1].replace(/\s+/g, '').toUpperCase();
+      if (c.length >= 2) codes.add(c);
+      if (codes.size >= limit) break;
+    }
+    if (codes.size >= limit) break;
+  }
+  return [...codes];
+}
+
+function countOccurrencesInText(text: string, needle: RegExp): number {
+  const m = text.match(needle);
+  return m ? m.length : 0;
+}
+
+async function buildVerificationEvidence(input: {
+  localPdfPaths: Array<{ filename: string; path: string }>;
+  codes: string[];
+  maxPagesPerDoc: number;
+}): Promise<EvidenceSnippet[]> {
+  const evidence: EvidenceSnippet[] = [];
+
+  // Second pass uses a different slice of pages: scan later pages too.
+  for (const pdf of input.localPdfPaths) {
+    const pageCount = getPdfPageCount(pdf.path) ?? 0;
+    const scanPages = pageCount > 0 ? Math.min(pageCount, input.maxPagesPerDoc) : input.maxPagesPerDoc;
+
+    // sample pages: first 10 + last 10 within scanPages (non-overlapping)
+    const pages = new Set<number>();
+    for (let p = 1; p <= Math.min(10, scanPages); p++) pages.add(p);
+    for (let p = Math.max(1, scanPages - 9); p <= scanPages; p++) pages.add(p);
+
+    for (const p of [...pages].sort((a, b) => a - b)) {
+      const pageText = pdftotextPage(pdf.path, p);
+      if (!pageText) continue;
+
+      // Look for explicit codes or exit/egress keywords to confirm counts.
+      const codeHits = input.codes.some((c) => new RegExp(`\\b${c.replace(/[-]/g, '[- ]?')}\\b`, 'i').test(pageText));
+      const isEgressy = /exit\s+sign|egress|occupant\s+load/i.test(pageText);
+      if (!codeHits && !isEgressy) continue;
+
+      const kind = detectKind(pageText);
+      const snippets = pickSnippetsFromPage(pageText, 2);
+      for (const snip of snippets) {
+        evidence.push({ filename: pdf.filename, page: p, kind, text: snip });
+      }
+    }
+  }
+
+  return evidence.slice(0, 80);
+}
+
+export async function estimatorTakeoffFromLocalPdfs(input: {
+  localPdfPaths: Array<{ filename: string; path: string }>;
+  maxPagesPerDoc?: number;
+}): Promise<{ evidence: EvidenceSnippet[]; result: EstimatorTakeoffResult }>{
+  const maxPagesPerDoc = input.maxPagesPerDoc ?? 40;
+
+  const evidence: EvidenceSnippet[] = [];
+
+  for (const pdf of input.localPdfPaths) {
+    const pageCount = getPdfPageCount(pdf.path) ?? 0;
+    const scanPages = pageCount > 0 ? Math.min(pageCount, maxPagesPerDoc) : maxPagesPerDoc;
+
+    for (let p = 1; p <= scanPages; p++) {
+      const pageText = pdftotextPage(pdf.path, p);
+      if (!pageText) continue;
+
+      const kind = detectKind(pageText);
+      if (kind === 'unknown') continue;
+
+      const snippets = pickSnippetsFromPage(pageText, 2);
+      for (const snip of snippets) {
+        evidence.push({ filename: pdf.filename, page: p, kind, text: snip });
+      }
+    }
+  }
+
+  const kindOrder: Record<EvidenceSnippet['kind'], number> = {
+    schedule: 1,
+    legend: 2,
+    egress: 3,
+    keynote: 4,
+    code: 5,
+    plan: 6,
+    unknown: 9,
+  };
+  evidence.sort((a, b) => (kindOrder[a.kind] - kindOrder[b.kind]) || a.filename.localeCompare(b.filename) || a.page - b.page);
+
+  const evidenceForPrompt = evidence.slice(0, 120);
+
+  const system =
+    `You are a senior signage estimator assistant. Your job is to produce a signage takeoff from construction bid PDFs.\n` +
+    `Rules:\n` +
+    `- Prefer authoritative sources (schedules > plans; egress tables for room signage; electrical plans for exit signs; health code for pool signs).\n` +
+    `- Every quantity MUST include citations: filename + page + an evidence snippet + why that source is authoritative.\n` +
+    `- Flag ambiguities and missing information for human review.\n` +
+    `- Output MUST be valid JSON matching the schema. No markdown.\n`;
+
+  const schemaHint = {
+    items: [
+      {
+        category: 'Exit Signs',
+        description: 'EXIT SIGN, LED, double-face',
+        qty: '12',
+        confidence: 0.88,
+        sources: [
+          {
+            filename: 'E1.01 Electrical Plans.pdf',
+            page: 42,
+            sheetRef: 'E1.01',
+            evidence: 'EXIT SIGN TYPE X ... QTY 12',
+            whyAuthoritative: 'Exit sign counts are governed by electrical/egress plan callouts',
+          },
+        ],
+        reviewFlags: ['verify sheet ref', 'confirm single vs double face'],
+      },
+    ],
+    discrepancyLog: [
+      {
+        issue: 'Schedule quantity conflicts with plan tag count for Type D7',
+        sources: [
+          { filename: 'Signage Schedule.pdf', page: 5, evidence: 'D7 ... QTY 8' },
+          { filename: 'A2.11 Plans.pdf', page: 17, evidence: 'D7 tags appear 10 times' },
+        ],
+      },
+    ],
+    missingItems: ['No signage legend found for pool regulatory signs'],
+    reviewFlags: ['Needs confirmation of authoritative schedule source'],
+    notes: 'Summary / assumptions / where to spot-check',
+  };
+
+  const user = {
+    bidContext: {
+      task: 'signage takeoff',
+      expectation: 'senior estimator level',
+    },
+    evidence: evidenceForPrompt,
+    outputSchema: schemaHint,
+  };
+
+  const completion = await openclawChatCompletions({
+    messages: [
+      { role: 'system', content: system },
+      { role: 'user', content: JSON.stringify(user) },
+    ],
+    temperature: 0.2,
+  });
+
+  const text = completion?.choices?.[0]?.message?.content;
+  if (!text || typeof text !== 'string') {
+    throw new Error('OpenClaw returned no text content');
+  }
+
+  let parsed: EstimatorTakeoffResult;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    const match = text.match(/\{[\s\S]*\}/);
+    if (!match) throw new Error('Failed to parse JSON from OpenClaw response');
+    parsed = JSON.parse(match[0]);
+  }
+
+  // ======================
+  // Second-pass verification
+  // ======================
+  const codes = extractLikelySignCodes(parsed.items, 25);
+  const verificationEvidence = await buildVerificationEvidence({
+    localPdfPaths: input.localPdfPaths,
+    codes,
+    maxPagesPerDoc,
+  });
+
+  // Deterministic cross-check: count code occurrences in verification pages and compare with qty when numeric.
+  let issuesFound = 0;
+  const verificationNotes: string[] = [];
+
+  for (const it of parsed.items.slice(0, 15)) {
+    const qtyNum = Number(String(it.qty).replace(/[^0-9.]/g, ''));
+    if (!Number.isFinite(qtyNum) || qtyNum <= 0) continue;
+
+    const code = (it.description.match(/\b([A-Z]{1,3}\s?-?\d{1,2})\b/) || [])[1];
+    if (!code) continue;
+
+    const re = new RegExp(`\\b${code.replace(/\s+/g, '').replace(/[-]/g, '[- ]?')}\\b`, 'gi');
+    const totalHits = verificationEvidence.reduce((s, e) => s + countOccurrencesInText(e.text, re), 0);
+
+    // Only flag when the signal is strong.
+    if (totalHits >= 3 && Math.abs(totalHits - qtyNum) / Math.max(1, qtyNum) >= 0.25) {
+      issuesFound++;
+      parsed.discrepancyLog = parsed.discrepancyLog || [];
+      parsed.discrepancyLog.push({
+        issue: `Second-pass check: code ${code} appears ~${totalHits}x in sampled pages; takeoff qty=${qtyNum}. Spot-check recommended.`,
+        sources: verificationEvidence.slice(0, 4).map((e) => ({ filename: e.filename, page: e.page, evidence: e.text })),
+      });
+      parsed.reviewFlags = parsed.reviewFlags || [];
+      parsed.reviewFlags.push(`Verify quantity for ${code} (second-pass mismatch)`);
+    }
+  }
+
+  verificationNotes.push(`Second pass scanned ${verificationEvidence.length} evidence snippets.`);
+  if (codes.length > 0) verificationNotes.push(`Checked codes: ${codes.slice(0, 10).join(', ')}${codes.length > 10 ? '…' : ''}`);
+
+  parsed.verification = {
+    method: 'two-pass: primary evidence scan + targeted later-page sampling + deterministic code hit cross-check',
+    checkedItems: Math.min(15, parsed.items.length),
+    issuesFound,
+    notes: verificationNotes.join(' '),
+  };
+
+  return { evidence: [...evidence, ...verificationEvidence], result: parsed };
+}

--- a/worker/takeoff-worker.ts
+++ b/worker/takeoff-worker.ts
@@ -7,13 +7,12 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 
 import { db } from '@/db';
-import { bids, documents, lineItems, takeoffJobs, takeoffJobDocuments } from '@/db/schema';
-import { and, eq, inArray, sql } from 'drizzle-orm';
+import { documents, lineItems, takeoffJobs, takeoffJobDocuments } from '@/db/schema';
+import { eq, inArray, sql } from 'drizzle-orm';
 import { downloadFile } from '@/lib/storage';
 import { scoreAllDocuments, formatScoresForLog, getTopDocument } from '@/extraction/scoring';
 import { detectSourceType, extractPdfText, tryFastPathExtraction } from '@/extraction/fast-path';
-import { runExtractionLoop } from '@/extraction/agentic';
-import type { DocumentInfo } from '@/extraction/agentic';
+import { estimatorTakeoffFromLocalPdfs } from '@/extraction/estimator-takeoff';
 
 type JobRow = typeof takeoffJobs.$inferSelect;
 
@@ -95,32 +94,6 @@ async function downloadBidPdfsToTemp(bidId: string): Promise<string> {
 
   console.log(`[takeoff-worker] Downloaded ${downloaded}/${bidDocs.length} PDFs to ${tempDir}`);
   return tempDir;
-}
-
-function buildExtractionNotes(entry: {
-  source: string;
-  isGrouped: boolean;
-  groupRange?: [number, number];
-  notes?: string;
-  sheetRefs: string[];
-}): string {
-  const parts: string[] = [];
-
-  if (entry.isGrouped && entry.groupRange) {
-    parts.push(`Grouped entry (${entry.groupRange[0]}-${entry.groupRange[1]})`);
-  }
-
-  parts.push(`Source: ${entry.source}`);
-
-  if (entry.sheetRefs.length > 0) {
-    parts.push(`Sheets: ${entry.sheetRefs.join(', ')}`);
-  }
-
-  if (entry.notes) {
-    parts.push(entry.notes);
-  }
-
-  return parts.join(' | ');
 }
 
 async function runJob(job: JobRow) {
@@ -217,42 +190,43 @@ async function runJob(job: JobRow) {
       }
     }
 
-    // STEP 3: agentic loop
-    const topScored = scoredDocs[0];
-    if (!topScored) throw new Error('No documents found in bid folder');
+    // STEP 3: estimator-grade takeoff (OpenClaw) + second-pass verification
+    const localPdfPaths = scoredDocs
+      .slice(0, 5)
+      .map((d) => ({ filename: d.filename, path: d.path }));
 
-    const topDocInfo: DocumentInfo = {
-      id: topScored.documentId,
-      name: topScored.filename,
-      path: topScored.path,
-      pageCount: undefined,
-    };
+    const { result, evidence } = await estimatorTakeoffFromLocalPdfs({
+      localPdfPaths,
+      maxPagesPerDoc: 60,
+    });
 
-    const result = await runExtractionLoop(localBidFolder, [topDocInfo]);
-
-    const values = result.entries.map((entry) => ({
+    const values = result.items.map((item, idx) => ({
       documentId: documentIds[0],
       bidId,
       userId: job.userId,
       tradeCode: 'division_10',
-      category: entry.name,
-      description: `${entry.name}${entry.roomNumber ? ` (${entry.roomNumber})` : ''}`,
-      estimatedQty: String(entry.quantity),
+      category: item.category,
+      description: item.description,
+      estimatedQty: item.qty,
       unit: 'EA',
-      notes: buildExtractionNotes(entry),
-      pageNumber: entry.pageNumbers[0],
-      pageReference: entry.sheetRefs.join(', '),
-      extractionConfidence: entry.confidence,
-      extractionModel: 'signage-agentic',
+      notes: [
+        ...((item.reviewFlags || []).map((f) => `FLAG: ${f}`)),
+        ...item.sources.slice(0, 3).map((s) => `Source: ${s.filename} p${s.page} — ${s.whyAuthoritative} — ${s.evidence}`),
+      ].join(' | '),
+      pageNumber: item.sources?.[0]?.page,
+      pageReference: item.sources?.[0]?.sheetRef,
+      extractionConfidence: item.confidence,
+      extractionModel: 'openclaw:Stratos-bid',
       rawExtractionJson: {
-        id: entry.id,
-        identifier: entry.identifier,
-        source: entry.source,
-        isGrouped: entry.isGrouped,
-        groupRange: entry.groupRange,
-        signTypeCode: entry.signTypeCode,
+        itemIndex: idx,
+        item,
+        discrepancyLog: result.discrepancyLog,
+        missingItems: result.missingItems,
+        reviewFlags: result.reviewFlags,
+        verification: result.verification,
+        evidenceSample: evidence.slice(0, 120),
       },
-      reviewStatus: entry.confidence >= 0.8 ? 'pending' : 'needs_review',
+      reviewStatus: item.confidence >= 0.8 ? 'pending' : 'needs_review',
       extractedAt: new Date(),
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -264,16 +238,17 @@ async function runJob(job: JobRow) {
       .update(documents)
       .set({
         extractionStatus: 'completed',
-        lineItemCount: result.entries.length,
+        lineItemCount: result.items.length,
         signageLegend: {
-          agenticExtraction: true,
-          totalCount: result.totalCount,
-          confidence: result.confidence,
-          iterationsUsed: result.iterationsUsed,
-          toolCallsCount: result.toolCallsCount,
+          estimatorTakeoff: true,
+          confidence: Math.max(0, Math.min(1, result.items.reduce((s, it) => s + (it.confidence || 0), 0) / Math.max(1, result.items.length))),
+          totalCount: result.items.length,
+          discrepancyCount: result.discrepancyLog.length,
+          missingItems: result.missingItems,
+          reviewFlags: result.reviewFlags,
+          verification: result.verification,
           notes: result.notes,
           extractedAt: new Date().toISOString(),
-          tokenUsage: result.tokenUsage,
         },
       })
       .where(inArray(documents.id, documentIds));
@@ -287,7 +262,7 @@ async function runJob(job: JobRow) {
       })
       .where(eq(takeoffJobs.id, job.id));
 
-    console.log(`[takeoff-worker] Agentic extraction complete for bid ${bidId}: ${result.entries.length} items`);
+    console.log(`[takeoff-worker] Estimator takeoff complete for bid ${bidId}: ${result.items.length} items`);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
 
@@ -318,7 +293,7 @@ async function main() {
   console.log(`[takeoff-worker] starting workerId=${WORKER_ID}`);
 
   // Sanity: DB should be reachable
-  // and inference configured (runExtractionLoop will use INFERENCE_* envs).
+  // and inference configured (OpenClaw env vars required).
 
   // eslint-disable-next-line no-constant-condition
   while (true) {


### PR DESCRIPTION
### A) Proper env var management for droplet worker
App Platform env vars **do not automatically apply** to the droplet worker (it’s a separate machine/process). This PR moves worker secret management into GitHub Actions + systemd:
- Workflow forwards secrets over SSH
- `scripts/deploy-droplet.sh` writes `/home/openclaw/stratos-bid/.env.worker` atomically when secrets are provided
- systemd unit already references `.env.worker` via `EnvironmentFile=`

### B) Senior-estimator quality: second-pass verification
Implements the second pass required by the takeoff skill:
- New module `src/extraction/estimator-takeoff.ts`
  - pass 1: evidence scan (bounded) + OpenClaw JSON takeoff w/ citations + flags
  - pass 2: *different slice* (first+last pages sampled) and deterministic cross-check of likely sign codes vs numeric qty
  - appends discrepancy + review flags when mismatch signal is strong
  - adds `result.verification` metadata
- Worker uses estimator-takeoff path (after fast-path) and stores verification info in `rawExtractionJson` + `signageLegend.verification`.

### Required GH Environment secrets (Production)
- DATABASE_URL
- DO_SPACES_BUCKET / DO_SPACES_REGION / (optional DO_SPACES_ENDPOINT)
- DO_SPACES_KEY / DO_SPACES_SECRET
- OPENCLAW_INFERENCE_URL / OPENCLAW_API_KEY / OPENCLAW_AGENT_MODEL

